### PR TITLE
`:use` user-specified packages in the temp package used internally by `safe-read`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _`&optional (stream *standard-input*) use-list` **→** `s-expression error-stat
   * Only lists are accepted as input. Atoms produce `:MALFORMED-INPUT`.
   * All macro characters other than `#\(` `#\)` `#\"` produce `:MALFORMED-INPUT`.
   * Package-qualified names (including keywords) produce `:MALFORMED-INPUT`.
-  * All symbols read are non-interned.
+  * All symbols read are non-interned except if `use-list` is provided, in which case symbols exported from the used packages will be interned in those packages.
   * Read always stops on EOF and newlines.
   * Reading from each stream is buffered, meaning that subsequent calls to SAFE-READ can produce a valid S-expression if it spans over multiple lines. An example is a list containing a string containing a newline.
   * No new S-expression must begin on the line where the previous one ended as they will be ignored.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ As of now, this repository includes variant of READ secure against internbombing
 * **Macro characters** - functioning of character macros within Lisp syntax, both standard and implementation-defined. They create simple dangers such as `#.(let (memleak) (loop (setf memleak (cons memleak memleak))))` along with more subtle ones that are not listed here.
 
 ### Function SAFE-READ
-_`&optional (stream *standard-input*)` **→** `s-expression error-status`_
-  * `S-EXPRESSION` - the read S-expression or NIL if reading was impossible.
+_`&optional (stream *standard-input*) use-list` **→** `s-expression error-status`_
+  * `S-EXPRESSION` - the read S-expression or NIL if reading was impossible. If `use-list` is specified, reading will occur in a package that uses the packages named in `use-list`.
   * `ERROR-STATUS` - one of `:INCOMPLETE-INPUT :MALFORMED-INPUT :INPUT-SIZE-EXCEEDED` or NIL in case of success.
 
 ### Variable *MAX-INPUT-SIZE*

--- a/safe-read.lisp
+++ b/safe-read.lisp
@@ -45,10 +45,10 @@
   (let* ((now (format nil "~S" (local-time:now)))
          (package-name (gensym (uiop:strcat "TEMP-PKG-" now "-")))
          (package-var (gensym))
-	 (use (if (eq (first body) :use-list)
-		  (prog1 (second body)
-		    (setf body (cddr body))))))
-		    
+         (use (if (eq (first body) :use-list)
+                  (prog1 (second body)
+                    (setf body (cddr body))))))
+                    
     `(let ((,package-var (or (find-package ',package-name)
                              (make-package ',package-name :use ,use))))
        (unwind-protect (let ((*package* ,package-var)) ,@body)
@@ -96,8 +96,8 @@
 (defmacro safe-read-handler-case (&body body)
   (let ((gensym (gensym)))
     `(with-temp-package ,@(if (eq (first body) :use-list)
-			      (prog1 (list :use-list (second body))
-				(setf body (cddr body))))
+                              (prog1 (list :use-list (second body))
+                                (setf body (cddr body))))
        (handler-case
            (flet ((clear-buffer (e)
                     (declare (ignore e))

--- a/test.lisp
+++ b/test.lisp
@@ -105,7 +105,20 @@
       (assert (null (safe-read stream)))
       (assert (equal '(3 2 1 0 1 2 3 4 5) (safe-read stream))))))
 
+;; SAFE-READ test for using symbols from packages.
+
+(defun test-6 ()
+  (with-input-from-string (stream "(first second third)")
+    (assert (equal '(first second third) (safe-read stream '(:common-lisp)))))
+  (with-input-from-string (stream "(foo bar baz)")
+    (loop for token in (safe-read stream '(:common-lisp))
+       for symbol in '(foo bar baz)
+       for string in '("FOO" "BAR" "BAZ")
+       do 
+	 (assert (not (eq token symbol)))
+	 (assert (string= (symbol-name token) string)))))
+
 ;; TODO one of the tests hangs indefinitely, check it
 
 (defun test ()
-  (test-1) (test-2) (test-3) (test-4) (test-5))
+  (test-1) (test-2) (test-3) (test-4) (test-5) (test-6))


### PR DESCRIPTION
This PR adds an optional argument to `safe-read`:

```
(safe-read &optional stream use-list)
```

If the new `use-list` argument is provided, the temp package used during reading will `:use` the packages specified in the list, resulting in output with symbols that are exported from those packages.

The `with-temp-package` macro is extended in a backwards-compatible way: If the body of the macro begins with `:use-list`, then the following element in the body will be taken to be the list of packages to use.  The `safe-read-handler-case` macro has received the same extension so that the `use-list` can be passed down from `safe-read`.